### PR TITLE
chore: remove unnecessary pulseaudio permission

### DIFF
--- a/org.dash.dash-core.json
+++ b/org.dash.dash-core.json
@@ -6,7 +6,6 @@
     "command": "dash-entrypoint.sh",
     "finish-args": [
         "--socket=x11",
-        "--socket=pulseaudio",
         "--device=dri",
         "--share=ipc",
         "--share=network",


### PR DESCRIPTION
## Summary
- Removes `--socket=pulseaudio` from finish-args
- Eliminates the Flathub warning: "Microphone access and audio playback - Can listen using microphones and play audio without asking permission"
- A cryptocurrency wallet has no need for audio/microphone access

## Test plan
- [ ] Verify the flatpak builds successfully
- [ ] Confirm the audio permission warning no longer appears on Flathub

🤖 Generated with [Claude Code](https://claude.com/claude-code)