### PR TITLE
Update Dash Core to 23.1.8

### DIFF
--- a/org.dash.dash-core.json
+++ b/org.dash.dash-core.json
@@ -34,16 +34,16 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/dashpay/dash/releases/download/v23.1.7/dashcore-23.1.7-x86_64-linux-gnu.tar.gz",
-                    "sha256": "4515634a76054a3adb5a2f3aaae150305737bc416c08568efb1b434050316213"
+                    "url": "https://github.com/dashpay/dash/releases/download/v23.1.8/dashcore-23.1.8-x86_64-linux-gnu.tar.gz",
+                    "sha256": "e664cad0fe860afa3d005be0db1eb06da598f2f83421083afae77191e3115825"
                 },
                 {
                     "type": "archive",
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://github.com/dashpay/dash/releases/download/v23.1.7/dashcore-23.1.7-aarch64-linux-gnu.tar.gz",
-                    "sha256": "1121580ed2172590284c642287316283c00306e517b236570ce1fc102bc649f5"
+                    "url": "https://github.com/dashpay/dash/releases/download/v23.1.8/dashcore-23.1.8-aarch64-linux-gnu.tar.gz",
+                    "sha256": "b96fef477ea01f5c47cc3d3f7de3fdd0bc8cc86f64660f720e8206d889604523"
                 }
             ]
         },
@@ -61,13 +61,13 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/dashpay/dash/v23.1.7/contrib/debian/dash-qt.desktop",
+                    "url": "https://raw.githubusercontent.com/dashpay/dash/v23.1.8/contrib/debian/dash-qt.desktop",
                     "sha256": "59b6125eb0732137026d33e1e61dc8b84e20f90baba176cc84899c41cf8201df"
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/dashpay/dash/v23.1.7/contrib/flatpak/org.dash.dash-core.metainfo.xml",
-                    "sha256": "76aac0eee61ec2d41572d5fe9dd5fc5ca99ca3675aa8c3dc5cf65f86b3efd1b6"
+                    "url": "https://raw.githubusercontent.com/dashpay/dash/v23.1.8/contrib/flatpak/org.dash.dash-core.metainfo.xml",
+                    "sha256": "ecde624c16ec73820ceb66fab9ff559ad367eccaddcef0d6ed92a5cf142928a8"
                 },
                 {
                     "type": "file",
@@ -75,7 +75,7 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/dashpay/dash/v23.1.7/share/pixmaps/dash-hicolor-scalable.svg",
+                    "url": "https://raw.githubusercontent.com/dashpay/dash/v23.1.8/share/pixmaps/dash-hicolor-scalable.svg",
                     "sha256": "1a403de47c676dce5852d4f5facef22312edf28707ba4ae3d669ea208301aba7"
                 },
                 {


### PR DESCRIPTION
Updates the manifest to Dash Core 23.1.8 ([upstream release](https://github.com/dashpay/dash/releases/tag/v23.1.8)).

## Changes

Only `org.dash.dash-core.json` is touched:

- x86_64 and aarch64 release archives repointed to the `v23.1.8` tarballs, with refreshed sha256.
- The three raw sources (`contrib/debian/dash-qt.desktop`, `contrib/flatpak/org.dash.dash-core.metainfo.xml`, `share/pixmaps/dash-hicolor-scalable.svg`) repointed to the `v23.1.8` tag.

## Validation

All five source entries carrying a URL and sha256 were downloaded and verified against the recorded digest — no entry was skipped:

| Source | Bytes | Verified |
| --- | --- | --- |
| `dashcore-23.1.8-x86_64-linux-gnu.tar.gz` | 61493895 | yes |
| `dashcore-23.1.8-aarch64-linux-gnu.tar.gz` | 59006895 | yes |
| `dash-qt.desktop` | 415 | yes |
| `org.dash.dash-core.metainfo.xml` | 1706 | yes |
| `dash-hicolor-scalable.svg` | 3574 | yes |

Also checked:

- Manifest parses as valid JSON (`jq`).
- No residual `23.1.7` references remain in the manifest.
- `git diff --check` passes; `git diff --name-only` is exactly `org.dash.dash-core.json`.
- The `v23.1.8` metainfo declares `<release date="2026-07-30" version="23.1.8"/>` as its newest entry.

Note: `dash-qt.desktop` and `dash-hicolor-scalable.svg` are byte-identical between `v23.1.7` and `v23.1.8`, so their sha256 values are intentionally unchanged while their URLs move to the new tag. Only the metainfo digest changed, as expected for a new release entry.